### PR TITLE
ignore undefined properties

### DIFF
--- a/src/van.debug.js
+++ b/src/van.debug.js
@@ -72,6 +72,7 @@ const tags = new Proxy(van.tags, {
       const [props, ...children] = protoOf(args[0] ?? 0) === Object.prototype ? args : [{}, ...args]
       const debugProps =  {}
       for (const [k, v] of Object.entries(props)) {
+        if(v === undefined) continue
         const validatePropValue = k.startsWith("on") ?
           v => (expect(typeof v === "function",
             `Invalid property value for ${k}: Only functions are allowed for on... handler`), v) :

--- a/src/van.js
+++ b/src/van.js
@@ -51,7 +51,8 @@ let tags = new Proxy((name, ...args) => {
   let dom = document.createElement(name)
   Obj.entries(props).forEach(([k, v]) => {
     let setter = dom[k] !== _undefined ? v => dom[k] = v : v => dom.setAttribute(k, v)
-    if (protoOf(v) === stateProto) bind(v, v => (setter(v), dom))
+    if(v == undefined){} 
+    else if (protoOf(v) === stateProto) bind(v, v => (setter(v), dom))
     else if (protoOf(v) === objProto) bind(...v["deps"], (...deps) => (setter(v["f"](...deps)), dom))
     else setter(v)
   })

--- a/src/van.js
+++ b/src/van.js
@@ -51,7 +51,7 @@ let tags = new Proxy((name, ...args) => {
   let dom = document.createElement(name)
   Obj.entries(props).forEach(([k, v]) => {
     let setter = dom[k] !== _undefined ? v => dom[k] = v : v => dom.setAttribute(k, v)
-    if(v == undefined){} 
+    if(v === undefined){} 
     else if (protoOf(v) === stateProto) bind(v, v => (setter(v), dom))
     else if (protoOf(v) === objProto) bind(...v["deps"], (...deps) => (setter(v["f"](...deps)), dom))
     else setter(v)

--- a/test/van.test.ts
+++ b/test/van.test.ts
@@ -564,7 +564,6 @@ const runTests = async (vanObj: VanForTesting, msgDom: Element, {debug}: BundleO
 
     tagsTest_invalidProp_nonPrimitiveValue: () => {
       assertError(/Only.*are valid prop value types/, () => a({href: null}))
-      assertError(/Only.*are valid prop value types/, () => a(<any>{href: undefined}))
       assertError(/Only.*are valid prop value types/, () => a(<any>{href: (x: number) => x * 2}))
 
       // State as property
@@ -749,7 +748,10 @@ const runTests = async (vanObj: VanForTesting, msgDom: Element, {debug}: BundleO
       const List = ({items}) => ul(items.map(it => li(it)))
       assertEq(List({items: ["Item 1", "Item 2", "Item 3"]}).outerHTML, "<ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>")
     },
-
+    propUndefined: () => {
+      const Comp = () => div(<any>{myprop: undefined});
+      assertEq(Comp().outerHTML, "<div></div>");
+    },
     table: () => {
       const Table = ({head, data}:
         {head?: readonly string[], data: readonly (string | number)[][]}) => table(


### PR DESCRIPTION
This PR allow properties to be undefined, as we do not always have control on what is given, removing the undefined props from user code would be cumbersome.