### PR TITLE
allow child to be undefined or null

### DIFF
--- a/src/van.debug.js
+++ b/src/van.debug.js
@@ -53,10 +53,10 @@ const isDomOrPrimitive = v => v instanceof Node || isValidPrimitive(v)
 
 const checkChildValid = child => {
   expect(
-    isDomOrPrimitive(child) || protoOf(child ?? 0) === stateProto && isValidPrimitive(child.val),
-    "Only DOM Node, string, number, boolean, bigint, and state of string, number, boolean or bigint are valid child of a DOM Node"
+    child == undefined ||  isDomOrPrimitive(child) || protoOf(child ?? 0) === stateProto && isValidPrimitive(child.val),
+    "Only DOM Node, string, number, boolean, bigint, and state of string, number, boolean, bigint, null or undefined are valid child of a DOM Node"
   )
-  expect(!child.isConnected, "You can't add a DOM Node that is already connected to document")
+  expect(!child || !child.isConnected, "You can't add a DOM Node that is already connected to document")
 }
 
 const add = (dom, ...children) => {

--- a/src/van.js
+++ b/src/van.js
@@ -42,7 +42,7 @@ let state = initVal => ({
 let toDom = v => v.nodeType ? v : new Text(v)
 
 let add = (dom, ...children) => (
-  children.flat(Infinity).forEach(child => child && dom.appendChild(
+  children.flat(Infinity).map(c => c ?? []).forEach(child => dom.appendChild(
     protoOf(child) === stateProto ? bind(child, v => v) : toDom(child))),
   dom)
 

--- a/src/van.js
+++ b/src/van.js
@@ -42,7 +42,7 @@ let state = initVal => ({
 let toDom = v => v.nodeType ? v : new Text(v)
 
 let add = (dom, ...children) => (
-  children.flat(Infinity).map(c => c ?? []).forEach(child => dom.appendChild(
+  children.flat(Infinity).filter(c => c != undefined).forEach(child => dom.appendChild(
     protoOf(child) === stateProto ? bind(child, v => v) : toDom(child))),
   dom)
 

--- a/src/van.js
+++ b/src/van.js
@@ -42,7 +42,7 @@ let state = initVal => ({
 let toDom = v => v.nodeType ? v : new Text(v)
 
 let add = (dom, ...children) => (
-  children.flat(Infinity).forEach(child => dom.appendChild(
+  children.flat(Infinity).forEach(child => child && dom.appendChild(
     protoOf(child) === stateProto ? bind(child, v => v) : toDom(child))),
   dom)
 

--- a/test/van.test.ts
+++ b/test/van.test.ts
@@ -744,6 +744,10 @@ const runTests = async (vanObj: VanForTesting, msgDom: Element, {debug}: BundleO
       const List = () => div("one", undefined, null)
       assertEq(List().outerHTML, "<div>one</div>")
     },
+    childrenWith0: () => {
+      const List = () => div([div(0), null])
+      assertEq(List().outerHTML, "<div><div>0</div></div>")
+    },
     bulletList: () => {
       const List = ({items}) => ul(items.map(it => li(it)))
       assertEq(List({items: ["Item 1", "Item 2", "Item 3"]}).outerHTML, "<ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>")

--- a/test/van.test.ts
+++ b/test/van.test.ts
@@ -583,8 +583,6 @@ const runTests = async (vanObj: VanForTesting, msgDom: Element, {debug}: BundleO
 
     tagsTest_invalidChild: () => {
       assertError(/Only.*are valid child of a DOM Node/, () => div(div(), <any>{}, p()))
-      assertError(/Only.*are valid child of a DOM Node/, () => div(div(), <any>null, p()))
-      assertError(/Only.*are valid child of a DOM Node/, () => div(div(), <any>undefined, p()))
       assertError(/Only.*are valid child of a DOM Node/, () => div(div(), <any>((x: number) => x * 2), p()))
 
       assertError(/Only.*are valid child of a DOM Node/, () => div(div(), state(<any>{}), p()))
@@ -608,8 +606,6 @@ const runTests = async (vanObj: VanForTesting, msgDom: Element, {debug}: BundleO
       const dom = div()
 
       assertError(/Only.*are valid child of a DOM Node/, () => add(dom, div(), <any>{}, p()))
-      assertError(/Only.*are valid child of a DOM Node/, () => add(dom, div(), <any>null, p()))
-      assertError(/Only.*are valid child of a DOM Node/, () => add(dom, div(), <any>undefined, p()))
       assertError(/Only.*are valid child of a DOM Node/, () => add(dom, div(), <any>((x: number) => x * 2), p()))
 
       assertError(/Only.*are valid child of a DOM Node/, () => add(dom, div(), state(<any>{}), p()))
@@ -744,7 +740,10 @@ const runTests = async (vanObj: VanForTesting, msgDom: Element, {debug}: BundleO
       await sleep(waitMsOnDomUpdates)
       assertEq((<Element>hiddenDom.firstChild).querySelector("div")!.innerText, "❤️: 1")
     }),
-
+    nullChildren: () => {
+      const List = () => div("one", undefined, null)
+      assertEq(List().outerHTML, "<div>one</div>")
+    },
     bulletList: () => {
       const List = ({items}) => ul(items.map(it => li(it)))
       assertEq(List({items: ["Item 1", "Item 2", "Item 3"]}).outerHTML, "<ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>")


### PR DESCRIPTION
This PR solves #16, allowing simpler client's code.