### PR TITLE
Make the test suite work on Firefox and Safari

### DIFF
--- a/test/van.test.js
+++ b/test/van.test.js
@@ -584,14 +584,16 @@ const runTests = async (vanObj, msgDom, { debug }) => {
             assertError("You should pass-in functions to register `onnew` handlers", () => s.onnew(++t));
         },
         stateTest_mutatingVal: () => {
+            // Catching different error messages as https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Read-only
+            const errorPattern = /Cannot assign to read only property '[ab]'|"[ab]" is read-only|Attempted to assign to readonly property./;
             {
                 const t = state({ a: 2 });
-                assertError("Cannot assign to read only property 'a'", () => t.val.a = 3);
+                assertError(errorPattern, () => t.val.a = 3);
             }
             {
                 const t = state({ b: 1 });
                 t.val = { b: 2 };
-                assertError("Cannot assign to read only property 'b'", () => t.val.b = 3);
+                assertError(errorPattern, () => t.val.b = 3);
             }
         },
         bindTest_noStates: () => {

--- a/test/van.test.nomodule.js
+++ b/test/van.test.nomodule.js
@@ -553,14 +553,16 @@
         assertError("You should pass-in functions to register `onnew` handlers", () => s.onnew(++t2));
       },
       stateTest_mutatingVal: () => {
+        // Catching different error messages as https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Read-only
+        const errorPattern = /Cannot assign to read only property '[ab]'|"[ab]" is read-only|Attempted to assign to readonly property./;
         {
           const t2 = state({ a: 2 });
-          assertError("Cannot assign to read only property 'a'", () => t2.val.a = 3);
+          assertError(errorPattern, () => t2.val.a = 3);
         }
         {
           const t2 = state({ b: 1 });
           t2.val = { b: 2 };
-          assertError("Cannot assign to read only property 'b'", () => t2.val.b = 3);
+          assertError(errorPattern, () => t2.val.b = 3);
         }
       },
       bindTest_noStates: () => {

--- a/test/van.test.ts
+++ b/test/van.test.ts
@@ -755,14 +755,16 @@ const runTests = async (vanObj: VanForTesting, msgDom: Element, {debug}: BundleO
     },
 
     stateTest_mutatingVal: () => {
+      // Catching different error messages as https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Read-only
+      const errorPattern = /Cannot assign to read only property '[ab]'|"[ab]" is read-only|Attempted to assign to readonly property./;
       {
         const t = state({a: 2})
-        assertError("Cannot assign to read only property 'a'", () => t.val.a = 3)
+        assertError(errorPattern, () => t.val.a = 3)
       }
       {
         const t = state({b: 1})
         t.val = {b: 2}
-        assertError("Cannot assign to read only property 'b'", () => t.val.b = 3)
+        assertError(errorPattern, () => t.val.b = 3)
       }
     },
 


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Read-only Firefox and Safari use different messages and this change considers that differences to make the test suite work on different mainstream browsers.