### PR TITLE
Update addAndScheduleOnFirst parameter name from func to f

### DIFF
--- a/src/van.js
+++ b/src/van.js
@@ -3,8 +3,8 @@
 // Aliasing some builtin symbols to reduce the bundle size.
 let Obj = Object, _undefined, protoOf = Obj.getPrototypeOf, doc = document
 
-let addAndScheduleOnFirst = (set, s, func, waitMs) =>
-  (set ?? (setTimeout(func, waitMs), new Set)).add(s)
+let addAndScheduleOnFirst = (set, s, f, waitMs) =>
+  (set ?? (setTimeout(f, waitMs), new Set)).add(s)
 
 let changedStates, curDeps
 


### PR DESCRIPTION
It's just a little nitpick. 

The parameters of the other functions (like `runAndCaptureDeps`, `derive`, ...etc)  use `f` as short for `function`, but only the `addAndScheduleOnFirst` function uses `func` as short for `function`, so I fixed it for coherence.

