### PR TITLE
feat: pass parent in function component

### DIFF
--- a/src/van.js
+++ b/src/van.js
@@ -91,7 +91,7 @@ let add = (dom, ...children) => {
   for (let c of children.flat(Infinity)) {
     let protoOfC = protoOf(c ?? 0)
     let child = protoOfC === stateProto ? bind(() => c.val) :
-      protoOfC === funcProto ? bind(c) : c
+      protoOfC === funcProto ? bind(c, dom) : c
     if (child != _undefined) dom.append(child)
   }
   return dom


### PR DESCRIPTION
I'm trying to write a diff plugin like this.

The problem I am encountering now is that I cannot get the parent element through the vanjs api.

```
van.tags.div(
  map(items, (value) => {
    return van.tags.div({
      textContent: value,
    });
  })
);

const map = (items, callback) => {
  // Can't get parent here.
  return (parent) => {
    const difference = diff(items.val, item.oldVal);
    difference.foreach((d) => {
      upsert(parent, callback(d));
    });
  };
}
```

I know this has some incompatible changes, is there a better way for me to get the parent element and maintain compatibility?

Another question is, can `oldVal` be undefined when state is created?