### PR TITLE
Enhance typing in vanjs-core and vanjs-jsx

### DIFF
--- a/addons/van_jsx/src/jsx-internal.d.ts
+++ b/addons/van_jsx/src/jsx-internal.d.ts
@@ -1,10 +1,12 @@
 import * as CSS from "csstype";
-import { State, ChildDom } from "vanjs-core";
+import { State, ChildDom, Tags, Props } from "vanjs-core";
 import { FunctionChild } from "./type";
 
 type OriginalElement = HTMLElement;
 
 export declare namespace JSX {
+  export interface JSXTags extends HTMLElementTagNameMap {}
+
   type HTMLAttributes<T> = Partial<Omit<T, "style" | "children">> & {
     style?: CSS.Properties;
     ref?: State<T>;
@@ -23,182 +25,14 @@ export declare namespace JSX {
   export interface ElementChildrenAttribute {
     children: {};
   }
+
   export interface IntrinsicAttributes {}
-  export interface IntrinsicElements {
-    a: HTMLAttributes<HTMLAnchorElement>;
-    abbr: HTMLAttributes<HTMLElement>;
-    address: HTMLAttributes<HTMLElement>;
-    area: HTMLAttributes<HTMLAreaElement>;
-    article: HTMLAttributes<HTMLElement>;
-    aside: HTMLAttributes<HTMLElement>;
-    audio: HTMLAttributes<HTMLAudioElement>;
-    b: HTMLAttributes<HTMLElement>;
-    base: HTMLAttributes<HTMLBaseElement>;
-    bdi: HTMLAttributes<HTMLElement>;
-    bdo: HTMLAttributes<HTMLElement>;
-    big: HTMLAttributes<HTMLElement>;
-    blockquote: HTMLAttributes<HTMLQuoteElement>;
-    body: HTMLAttributes<HTMLBodyElement>;
-    br: HTMLAttributes<HTMLBRElement>;
-    button: HTMLAttributes<HTMLButtonElement>;
-    canvas: HTMLAttributes<HTMLCanvasElement>;
-    caption: HTMLAttributes<HTMLTableCaptionElement>;
-    cite: HTMLAttributes<HTMLElement>;
-    code: HTMLAttributes<HTMLElement>;
-    col: HTMLAttributes<HTMLTableColElement>;
-    colgroup: HTMLAttributes<HTMLTableColElement>;
-    data: HTMLAttributes<HTMLDataElement>;
-    datalist: HTMLAttributes<HTMLDataListElement>;
-    dd: HTMLAttributes<HTMLElement>;
-    del: HTMLAttributes<HTMLModElement>;
-    details: HTMLAttributes<HTMLDetailsElement>;
-    dfn: HTMLAttributes<HTMLElement>;
-    dialog: HTMLAttributes<HTMLDialogElement>;
-    div: HTMLAttributes<HTMLDivElement>;
-    dl: HTMLAttributes<HTMLDListElement>;
-    dt: HTMLAttributes<HTMLElement>;
-    em: HTMLAttributes<HTMLElement>;
-    embed: HTMLAttributes<HTMLEmbedElement>;
-    fieldset: HTMLAttributes<HTMLFieldSetElement>;
-    figcaption: HTMLAttributes<HTMLElement>;
-    figure: HTMLAttributes<HTMLElement>;
-    footer: HTMLAttributes<HTMLElement>;
-    form: HTMLAttributes<HTMLFormElement>;
-    h1: HTMLAttributes<HTMLHeadingElement>;
-    h2: HTMLAttributes<HTMLHeadingElement>;
-    h3: HTMLAttributes<HTMLHeadingElement>;
-    h4: HTMLAttributes<HTMLHeadingElement>;
-    h5: HTMLAttributes<HTMLHeadingElement>;
-    h6: HTMLAttributes<HTMLHeadingElement>;
-    head: HTMLAttributes<HTMLHeadElement>;
-    header: HTMLAttributes<HTMLElement>;
-    hgroup: HTMLAttributes<HTMLElement>;
-    hr: HTMLAttributes<HTMLHRElement>;
-    html: HTMLAttributes<HTMLHtmlElement>;
-    i: HTMLAttributes<HTMLElement>;
-    iframe: HTMLAttributes<HTMLIFrameElement>;
-    img: HTMLAttributes<HTMLImageElement>;
-    input: HTMLAttributes<HTMLInputElement>;
-    ins: HTMLAttributes<HTMLModElement>;
-    kbd: HTMLAttributes<HTMLElement>;
-    keygen: HTMLAttributes<HTMLUnknownElement>;
-    label: HTMLAttributes<HTMLLabelElement>;
-    legend: HTMLAttributes<HTMLLegendElement>;
-    li: HTMLAttributes<HTMLLIElement>;
-    link: HTMLAttributes<HTMLLinkElement>;
-    main: HTMLAttributes<HTMLElement>;
-    map: HTMLAttributes<HTMLMapElement>;
-    mark: HTMLAttributes<HTMLElement>;
-    marquee: HTMLAttributes<HTMLMarqueeElement>;
-    menu: HTMLAttributes<HTMLMenuElement>;
-    menuitem: HTMLAttributes<HTMLUnknownElement>;
-    meta: HTMLAttributes<HTMLMetaElement>;
-    meter: HTMLAttributes<HTMLMeterElement>;
-    nav: HTMLAttributes<HTMLElement>;
-    noscript: HTMLAttributes<HTMLElement>;
-    object: HTMLAttributes<HTMLObjectElement>;
-    ol: HTMLAttributes<HTMLOListElement>;
-    optgroup: HTMLAttributes<HTMLOptGroupElement>;
-    option: HTMLAttributes<HTMLOptionElement>;
-    output: HTMLAttributes<HTMLOutputElement>;
-    p: HTMLAttributes<HTMLParagraphElement>;
-    param: HTMLAttributes<HTMLParamElement>;
-    picture: HTMLAttributes<HTMLPictureElement>;
-    pre: HTMLAttributes<HTMLPreElement>;
-    progress: HTMLAttributes<HTMLProgressElement>;
-    q: HTMLAttributes<HTMLQuoteElement>;
-    rp: HTMLAttributes<HTMLElement>;
-    rt: HTMLAttributes<HTMLElement>;
-    ruby: HTMLAttributes<HTMLElement>;
-    s: HTMLAttributes<HTMLElement>;
-    samp: HTMLAttributes<HTMLElement>;
-    script: HTMLAttributes<HTMLScriptElement>;
-    search: HTMLAttributes<HTMLElement>;
-    section: HTMLAttributes<HTMLElement>;
-    select: HTMLAttributes<HTMLSelectElement>;
-    slot: HTMLAttributes<HTMLSlotElement>;
-    small: HTMLAttributes<HTMLElement>;
-    source: HTMLAttributes<HTMLSourceElement>;
-    span: HTMLAttributes<HTMLSpanElement>;
-    strong: HTMLAttributes<HTMLElement>;
-    style: HTMLAttributes<HTMLStyleElement>;
-    sub: HTMLAttributes<HTMLElement>;
-    summary: HTMLAttributes<HTMLElement>;
-    sup: HTMLAttributes<HTMLElement>;
-    table: HTMLAttributes<HTMLTableElement>;
-    tbody: HTMLAttributes<HTMLTableSectionElement>;
-    td: HTMLAttributes<HTMLTableCellElement>;
-    textarea: HTMLAttributes<HTMLTextAreaElement>;
-    tfoot: HTMLAttributes<HTMLTableSectionElement>;
-    th: HTMLAttributes<HTMLTableCellElement>;
-    thead: HTMLAttributes<HTMLTableSectionElement>;
-    time: HTMLAttributes<HTMLTimeElement>;
-    title: HTMLAttributes<HTMLTitleElement>;
-    tr: HTMLAttributes<HTMLTableRowElement>;
-    track: HTMLAttributes<HTMLTrackElement>;
-    u: HTMLAttributes<HTMLElement>;
-    ul: HTMLAttributes<HTMLUListElement>;
-    var: HTMLAttributes<HTMLElement>;
-    video: HTMLAttributes<HTMLVideoElement>;
-    wbr: HTMLAttributes<HTMLElement>;
-    svg: SVGAttributes<SVGSVGElement>;
-    animate: SVGAttributes<SVGAnimateElement>;
-    circle: SVGAttributes<SVGCircleElement>;
-    animateMotion: SVGAttributes<SVGAnimateMotionElement>;
-    animateTransform: SVGAttributes<SVGAnimateTransformElement>;
-    clipPath: SVGAttributes<SVGClipPathElement>;
-    defs: SVGAttributes<SVGDefsElement>;
-    desc: SVGAttributes<SVGDescElement>;
-    ellipse: SVGAttributes<SVGEllipseElement>;
-    feBlend: SVGAttributes<SVGFEBlendElement>;
-    feColorMatrix: SVGAttributes<SVGFEColorMatrixElement>;
-    feComponentTransfer: SVGAttributes<SVGFEComponentTransferElement>;
-    feComposite: SVGAttributes<SVGFECompositeElement>;
-    feConvolveMatrix: SVGAttributes<SVGFEConvolveMatrixElement>;
-    feDiffuseLighting: SVGAttributes<SVGFEDiffuseLightingElement>;
-    feDisplacementMap: SVGAttributes<SVGFEDisplacementMapElement>;
-    feDistantLight: SVGAttributes<SVGFEDistantLightElement>;
-    feDropShadow: SVGAttributes<SVGFEDropShadowElement>;
-    feFlood: SVGAttributes<SVGFEFloodElement>;
-    feFuncA: SVGAttributes<SVGFEFuncAElement>;
-    feFuncB: SVGAttributes<SVGFEFuncBElement>;
-    feFuncG: SVGAttributes<SVGFEFuncGElement>;
-    feFuncR: SVGAttributes<SVGFEFuncRElement>;
-    feGaussianBlur: SVGAttributes<SVGFEGaussianBlurElement>;
-    feImage: SVGAttributes<SVGFEImageElement>;
-    feMerge: SVGAttributes<SVGFEMergeElement>;
-    feMergeNode: SVGAttributes<SVGFEMergeNodeElement>;
-    feMorphology: SVGAttributes<SVGFEMorphologyElement>;
-    feOffset: SVGAttributes<SVGFEOffsetElement>;
-    fePointLight: SVGAttributes<SVGFEPointLightElement>;
-    feSpecularLighting: SVGAttributes<SVGFESpecularLightingElement>;
-    feSpotLight: SVGAttributes<SVGFESpotLightElement>;
-    feTile: SVGAttributes<SVGFETileElement>;
-    feTurbulence: SVGAttributes<SVGFETurbulenceElement>;
-    filter: SVGAttributes<SVGFilterElement>;
-    foreignObject: SVGAttributes<SVGForeignObjectElement>;
-    g: SVGAttributes<SVGGElement>;
-    image: SVGAttributes<SVGImageElement>;
-    line: SVGAttributes<SVGLineElement>;
-    linearGradient: SVGAttributes<SVGLinearGradientElement>;
-    marker: SVGAttributes<SVGMarkerElement>;
-    mask: SVGAttributes<SVGMaskElement>;
-    metadata: SVGAttributes<SVGMetadataElement>;
-    mpath: SVGAttributes<SVGMPathElement>;
-    path: SVGAttributes<SVGPathElement>;
-    pattern: SVGAttributes<SVGPatternElement>;
-    polygon: SVGAttributes<SVGPolygonElement>;
-    polyline: SVGAttributes<SVGPolylineElement>;
-    radialGradient: SVGAttributes<SVGRadialGradientElement>;
-    rect: SVGAttributes<SVGRectElement>;
-    set: SVGAttributes<SVGSetElement>;
-    stop: SVGAttributes<SVGStopElement>;
-    switch: SVGAttributes<SVGSwitchElement>;
-    symbol: SVGAttributes<SVGSymbolElement>;
-    text: SVGAttributes<SVGTextElement>;
-    textPath: SVGAttributes<SVGTextPathElement>;
-    tspan: SVGAttributes<SVGTSpanElement>;
-    use: SVGAttributes<SVGUseElement>;
-    view: SVGAttributes<SVGViewElement>;
-  }
+
+  export type IntrinsicElements = {
+    [K in keyof Tags]: ReturnType<Tags[K]> extends HTMLElement
+      ? HTMLAttributes<Props<ReturnType<Tags[K]>>>
+      : ReturnType<Tags[K]> extends SVGElement
+      ? SVGAttributes<Props<ReturnType<Tags[K]>>>
+      : never;
+  };
 }

--- a/src/van.d.ts
+++ b/src/van.d.ts
@@ -1,182 +1,58 @@
 export interface State<T> {
-  val: T
-  readonly oldVal: T
+  val: T;
+  readonly oldVal: T;
 }
 
 // Defining readonly view of State<T> for covariance.
 // Basically we want StateView<string> to implement StateView<string | number>
-export type StateView<T> = Readonly<State<T>>
+export type StateView<T> = Readonly<State<T>>;
 
-export type Primitive = string | number | boolean | bigint
+export type Primitive = string | number | boolean | bigint;
 
-export type PropValue = Primitive | ((e: any) => void) | null
+export type PropValue<TProp = any> = TProp | StateView<TProp> | (() => TProp);
 
-export type Props = Record<string, PropValue | StateView<PropValue> | (() => PropValue)>
+export type Props<TElement extends Element> = Partial<{
+  [K in keyof TElement]: PropValue<TElement[K]>;
+}>;
 
-export type ValidChildDomValue = Primitive | Node | null | undefined
+export type ValidChildDomValue = Primitive | Node | null | undefined;
 
-export type BindingFunc = ((dom?: Node) => ValidChildDomValue) | ((dom?: Element) => Element)
+export type BindingFunc = (dom?: Element) => Element;
 
-export type ChildDom = ValidChildDomValue | StateView<Primitive | null | undefined> | BindingFunc | readonly ChildDom[]
+export type ChildDom =
+  | ValidChildDomValue
+  | StateView<Primitive | null | undefined>
+  | BindingFunc
+  | readonly ChildDom[];
 
-export type TagFunc<Result> = (first?: Props | ChildDom, ...rest: readonly ChildDom[]) => Result
+export type VanElement<TElement extends Element> = (
+  first?: Props<TElement> | ChildDom,
+  ...rest: readonly ChildDom[]
+) => TElement;
 
-interface Tags extends Readonly<Record<string, TagFunc<Element>>> {
-  // Register known element types
-  // Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element
-
-  // Main root
-  readonly html: TagFunc<HTMLHtmlElement>
-
-  // Document metadata
-  readonly base: TagFunc<HTMLBaseElement>
-  readonly head: TagFunc<HTMLHeadElement>
-  readonly link: TagFunc<HTMLLinkElement>
-  readonly meta: TagFunc<HTMLMetaElement>
-  readonly style: TagFunc<HTMLStyleElement>
-  readonly title: TagFunc<HTMLTitleElement>
-
-  // Sectioning root
-  readonly body: TagFunc<HTMLBodyElement>
-
-  // Content sectioning
-  readonly address: TagFunc<HTMLElement>
-  readonly article: TagFunc<HTMLElement>
-  readonly aside: TagFunc<HTMLElement>
-  readonly footer: TagFunc<HTMLElement>
-  readonly header: TagFunc<HTMLElement>
-  readonly h1: TagFunc<HTMLHeadingElement>
-  readonly h2: TagFunc<HTMLHeadingElement>
-  readonly h3: TagFunc<HTMLHeadingElement>
-  readonly h4: TagFunc<HTMLHeadingElement>
-  readonly h5: TagFunc<HTMLHeadingElement>
-  readonly h6: TagFunc<HTMLHeadingElement>
-  readonly hgroup: TagFunc<HTMLElement>
-  readonly main: TagFunc<HTMLElement>
-  readonly nav: TagFunc<HTMLElement>
-  readonly section: TagFunc<HTMLElement>
-
-  // Text content
-  readonly blockquote: TagFunc<HTMLQuoteElement>
-  readonly dd: TagFunc<HTMLElement>
-  readonly div: TagFunc<HTMLDivElement>
-  readonly dl: TagFunc<HTMLDListElement>
-  readonly dt: TagFunc<HTMLElement>
-  readonly figcaption: TagFunc<HTMLElement>
-  readonly figure: TagFunc<HTMLElement>
-  readonly hr: TagFunc<HTMLHRElement>
-  readonly li: TagFunc<HTMLLIElement>
-  readonly menu: TagFunc<HTMLMenuElement>
-  readonly ol: TagFunc<HTMLOListElement>
-  readonly p: TagFunc<HTMLParagraphElement>
-  readonly pre: TagFunc<HTMLPreElement>
-  readonly ul: TagFunc<HTMLUListElement>
-
-  // Inline text semantics
-  readonly a: TagFunc<HTMLAnchorElement>
-  readonly abbr: TagFunc<HTMLElement>
-  readonly b: TagFunc<HTMLElement>
-  readonly bdi: TagFunc<HTMLElement>
-  readonly bdo: TagFunc<HTMLElement>
-  readonly br: TagFunc<HTMLBRElement>
-  readonly cite: TagFunc<HTMLElement>
-  readonly code: TagFunc<HTMLElement>
-  readonly data: TagFunc<HTMLDataElement>
-  readonly dfn: TagFunc<HTMLElement>
-  readonly em: TagFunc<HTMLElement>
-  readonly i: TagFunc<HTMLElement>
-  readonly kbd: TagFunc<HTMLElement>
-  readonly mark: TagFunc<HTMLElement>
-  readonly q: TagFunc<HTMLQuoteElement>
-  readonly rp: TagFunc<HTMLElement>
-  readonly rt: TagFunc<HTMLElement>
-  readonly ruby: TagFunc<HTMLElement>
-  readonly s: TagFunc<HTMLElement>
-  readonly samp: TagFunc<HTMLElement>
-  readonly small: TagFunc<HTMLElement>
-  readonly span: TagFunc<HTMLSpanElement>
-  readonly strong: TagFunc<HTMLElement>
-  readonly sub: TagFunc<HTMLElement>
-  readonly sup: TagFunc<HTMLElement>
-  readonly time: TagFunc<HTMLTimeElement>
-  readonly u: TagFunc<HTMLElement>
-  readonly var: TagFunc<HTMLElement>
-  readonly wbr: TagFunc<HTMLElement>
-
-  // Image and multimedia
-  readonly area: TagFunc<HTMLAreaElement>
-  readonly audio: TagFunc<HTMLAudioElement>
-  readonly img: TagFunc<HTMLImageElement>
-  readonly map: TagFunc<HTMLMapElement>
-  readonly track: TagFunc<HTMLTrackElement>
-  readonly video: TagFunc<HTMLVideoElement>
-
-  // Embedded content
-  readonly embed: TagFunc<HTMLEmbedElement>
-  readonly iframe: TagFunc<HTMLIFrameElement>
-  readonly object: TagFunc<HTMLObjectElement>
-  readonly picture: TagFunc<HTMLPictureElement>
-  readonly source: TagFunc<HTMLSourceElement>
-
-  // Scripting
-  readonly canvas: TagFunc<HTMLCanvasElement>
-  readonly noscript: TagFunc<HTMLElement>
-  readonly script: TagFunc<HTMLScriptElement>
-
-  // Demarcating edits
-  readonly del: TagFunc<HTMLModElement>
-  readonly ins: TagFunc<HTMLModElement>
-
-  // Table content
-  readonly caption: TagFunc<HTMLTableCaptionElement>
-  readonly col: TagFunc<HTMLTableColElement>
-  readonly colgroup: TagFunc<HTMLTableColElement>
-  readonly table: TagFunc<HTMLTableElement>
-  readonly tbody: TagFunc<HTMLTableSectionElement>
-  readonly td: TagFunc<HTMLTableCellElement>
-  readonly tfoot: TagFunc<HTMLTableSectionElement>
-  readonly th: TagFunc<HTMLTableCellElement>
-  readonly thead: TagFunc<HTMLTableSectionElement>
-  readonly tr: TagFunc<HTMLTableRowElement>
-
-  // Forms
-  readonly button: TagFunc<HTMLButtonElement>
-  readonly datalist: TagFunc<HTMLDataListElement>
-  readonly fieldset: TagFunc<HTMLFieldSetElement>
-  readonly form: TagFunc<HTMLFormElement>
-  readonly input: TagFunc<HTMLInputElement>
-  readonly label: TagFunc<HTMLLabelElement>
-  readonly legend: TagFunc<HTMLLegendElement>
-  readonly meter: TagFunc<HTMLMeterElement>
-  readonly optgroup: TagFunc<HTMLOptGroupElement>
-  readonly option: TagFunc<HTMLOptionElement>
-  readonly output: TagFunc<HTMLOutputElement>
-  readonly progress: TagFunc<HTMLProgressElement>
-  readonly select: TagFunc<HTMLSelectElement>
-  readonly textarea: TagFunc<HTMLTextAreaElement>
-
-  // Interactive elements
-  readonly details: TagFunc<HTMLDetailsElement>
-  readonly dialog: TagFunc<HTMLDialogElement>
-  readonly summary: TagFunc<HTMLElement>
-
-  // Web Components
-  readonly slot: TagFunc<HTMLSlotElement>
-  readonly template: TagFunc<HTMLTemplateElement>
-}
+export type Tags = {
+  [K in keyof HTMLElementTagNameMap]: VanElement<HTMLElementTagNameMap[K]>;
+};
 
 export interface Van {
-  readonly state: <T>(initVal: T) => State<T>
-  readonly val: <T>(s: T | StateView<T>) => T
-  readonly oldVal: <T>(s: T | StateView<T>) => T
-  readonly derive: <T>(f: () => T) => State<T>
-  readonly add: (dom: Element, ...children: readonly ChildDom[]) => Element
-  readonly _: (f: () => PropValue) => () => PropValue
-  readonly tags: Tags
-  readonly tagsNS: (namespaceURI: string) => Readonly<Record<string, TagFunc<Element>>>
-  readonly hydrate: <T extends Node>(dom: T, f: (dom: T) => T | null | undefined) => T
+  readonly state: <T>(initVal: T) => State<T>;
+  readonly val: <T>(s: T | StateView<T>) => T;
+  readonly oldVal: <T>(s: T | StateView<T>) => T;
+  readonly derive: <T>(f: () => T) => State<T>;
+  readonly add: (dom: Element, ...children: readonly ChildDom[]) => Element;
+  readonly _: <TProp = any>(
+    f: () => PropValue<TProp>
+  ) => () => PropValue<TProp>;
+  readonly tags: Tags;
+  readonly tagsNS: (
+    namespaceURI: string
+  ) => Readonly<Record<string, VanElement<Element>>>;
+  readonly hydrate: <T extends Node>(
+    dom: T,
+    f: (dom: T) => T | null | undefined
+  ) => T;
 }
 
-declare const van: Van
+declare const van: Van;
 
-export default van
+export default van;


### PR DESCRIPTION
This PR fixes #142 
It modifies the Tags and Props in the core.
And uses the modified types in VanJSX. 