### PR TITLE
Fix type definition for calc

### DIFF
--- a/x/src/van-x.d.ts
+++ b/x/src/van-x.d.ts
@@ -10,7 +10,7 @@ type _Reactive<T> = T extends object ?
 export type Reactive<T extends object> = _Reactive<T>
 export type DeReactive<T> = T extends ReactiveObj ? Omit<T, typeof reactiveSym> : T
 
-export declare const calc: <R>(f: () => R) => R
+export declare const calc: <R>(f: () => R) => () => R
 export declare const reactive: <T extends object>(obj: T) => Reactive<T>
 
 export type StateOf<T> = { readonly [K in keyof T]: State<_Reactive<T[K]>> }


### PR DESCRIPTION
```javascript
let calc = f => (f[isCalcFunc] = 1, f)

const num = calc(() => 123)
console.log(num() == 123)  // true
```