### PR TITLE
Proposal for `str` tagged template literal

### DIFF
--- a/src/van.js
+++ b/src/van.js
@@ -131,4 +131,6 @@ let updateDoms = () => {
 
 let hydrate = (dom, f) => update(dom, bind(f, dom))
 
-export default {add, _, tags: tagsNS(), tagsNS, state, val, oldVal, derive, hydrate}
+let str = (strs, ...vals) => () => strs[0] + vals.reduce((acc, v, i) => acc + val(v) + strs[i + 1], "")
+
+export default {add, _, tags: tagsNS(), tagsNS, state, val, oldVal, derive, hydrate, str}


### PR DESCRIPTION
Usage:

- old way
```ts
const Hello = (state1: State<number>, state2: State<string>, state3: State<number>) 
  => p(() => `1: ${state1.val},2: ${state2.val},3: ${state3.val}`)
```
- with `str`
```ts
const Hello = (state1: State<number>, state2: State<string>, state3: State<number>) 
  => p(str`1: ${state1},2: ${state2},3: ${state3}`)
```

Do you like it? I can also add this separately in `van-element`, since this is useful for styling 😄 