### PR TITLE
fix: update jsx export

### DIFF
--- a/addons/van_jsx/src/index.js
+++ b/addons/van_jsx/src/index.js
@@ -3,4 +3,3 @@ export function createState(v) {
     return van.state(v);
 }
 export { default as createElement, default as jsx, default as jsxDEV, } from "./createElement";
-export * from "./type";

--- a/addons/van_jsx/src/jsx-dev-runtime.js
+++ b/addons/van_jsx/src/jsx-dev-runtime.js
@@ -1,2 +1,1 @@
 export * from "./index";
-export * from "./jsx-runtime";


### PR DESCRIPTION
- Remove wrong js export statement

related [issue ](https://github.com/vanjs-org/van/issues/233)

Since the code is a compiled product, some export * statements will be retained, but this will cause errors and need to be removed.

@Tao-VanJS PTAL