### PR TITLE
Introducing VanJS Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Simplicity at its core. Only 5 functions (`van.tags`, `van.add`, `van.state`, `v
 * Debugging complex dependencies in your app? checkout [**VanGraph**](https://github.com/vanjs-org/van/tree/main/graph)
 * For questions, feedback or general discussions, visit our [Discussions](https://github.com/vanjs-org/van/discussions) page
 * [How did **VanJS** get its name?](https://vanjs.org/about#name)
+* You can [Ask VanJS Guru](https://gurubase.io/g/vanjs), it is a VanJS-focused AI to answer your questions.
 
 ## IDE Plug-ins
 
@@ -245,5 +246,3 @@ Contact us: [@taoxin](https://twitter.com/intent/follow?region=follow_link&scree
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
-
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20VanJS%20Guru-006BFF)](https://gurubase.io/g/vanjs)

--- a/README.md
+++ b/README.md
@@ -245,3 +245,5 @@ Contact us: [@taoxin](https://twitter.com/intent/follow?region=follow_link&scree
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20VanJS%20Guru-006BFF)](https://gurubase.io/g/vanjs)


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [VanJS Guru](https://gurubase.io/g/vanjs) to Gurubase. VanJS Guru uses the data from this repo and data from the [docs](https://vanjs.org) to answer questions by leveraging the LLM.

In this PR, I showcased the "VanJS Guru", which highlights that VanJS now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable VanJS Guru in Gurubase, just let me know that's totally fine.
