### PR TITLE
fix: handle boolean attributes and attribute reactivity

### DIFF
--- a/addons/van_jsx/src/createElement.js
+++ b/addons/van_jsx/src/createElement.js
@@ -18,6 +18,15 @@ const createElement = (jsxTag, { children, style, ref, ...props }) => {
                 ele.addEventListener(key.replace("on", "").toLowerCase(), value);
                 continue;
             }
+
+            // Handle reactive attributes
+            if (typeof value === "object" && "val" in value) {
+                van.derive(() => {
+                  setAttribute(ele, key, value.val);
+                });
+                continue;
+            }
+            
             setAttribute(ele, key, value);
             continue;
         }

--- a/addons/van_jsx/src/hyper.js
+++ b/addons/van_jsx/src/hyper.js
@@ -34,4 +34,11 @@ export const setAttribute = (element, key, value) => {
         element.setAttribute(key, value);
         return;
     }
+    // Set Boolean Attribute
+    if (typeof value === "boolean") {
+        if (value) {
+          element.setAttribute(key, "");
+          return;
+        }
+    }
 };

--- a/addons/van_jsx/src/hyper.js
+++ b/addons/van_jsx/src/hyper.js
@@ -40,5 +40,6 @@ export const setAttribute = (element, key, value) => {
           element.setAttribute(key, "");
           return;
         }
+        element.removeAttribute(key);
     }
 };


### PR DESCRIPTION
At the moment adding the `disabled` attribute to a `<button />` results in the attribute not being passed. This PR should solve this.