### PR TITLE
Make tag function work with Custom Elements 'is' property

### DIFF
--- a/src/van.js
+++ b/src/van.js
@@ -94,7 +94,7 @@ let add = (dom, ...children) => {
 
 let tag = (ns, name, ...args) => {
   let [props, ...children] = protoOf(args[0] ?? 0) === objProto ? args : [{}, ...args]
-  let dom = ns ? document.createElementNS(ns, name) : document.createElement(name)
+  let dom = ns ? document.createElementNS(ns, name) : document.createElement(name, props)
   for (let [k, v] of Object.entries(props)) {
     let getPropDescriptor = proto => proto ?
       Object.getOwnPropertyDescriptor(proto, k) ?? getPropDescriptor(protoOf(proto)) :


### PR DESCRIPTION
Pass in props as options to allow createElement to work with custom elements 'is' property