### PR TITLE
Dismiss modal on backdrop click

### DIFF
--- a/components/van-ui.ts
+++ b/components/van-ui.ts
@@ -94,10 +94,17 @@ export const Modal = (
   }
 
   document.activeElement instanceof HTMLElement && document.activeElement.blur()
-  return () => closed.val ? null : div(
-    {class: backgroundClass, style: toStyleStr(backgroundStyle)},
-    div({class: modalClass, style: toStyleStr(modalStyle)}, children),
-  )
+  return () => {
+      if (closed.val) return null
+      const backdrop = div(
+          {class: backgroundClass, style: toStyleStr(backgroundStyle)},
+          div({class: modalClass, style: toStyleStr(modalStyle)}, children),
+      )
+      backdrop.addEventListener("click", function (e) {
+          if (e.target == this) closed.val = true
+      })
+      return backdrop
+  }
 }
 
 export interface TabsProps {


### PR DESCRIPTION
I would expect that modals close when clicking on the backdrop.
If this should not be the default behaviour, an option could be added. 
I feel it should be default at least when `Modal` is used by `choose`.