### PR TITLE
Close modal on mousedown instead of click

### DIFF
--- a/components/van-ui.ts
+++ b/components/van-ui.ts
@@ -103,7 +103,7 @@ export const Modal = (
           div({class: modalClass, style: toStyleStr(modalStyle)}, children),
       )
       clickBackgroundToClose &&
-        bgDom.addEventListener("click", e => e.target === bgDom && (closed.val = true))
+        bgDom.addEventListener("mousedown", e => e.target === bgDom && (closed.val = true))
       return bgDom
   }
 }


### PR DESCRIPTION
Using click produces unexpected closing of the modal when trying to select text on an input field inside the modal by dragging with the mouse and releasing the button outside of the input.